### PR TITLE
Allow multiple pending sqs.receiveMessage() calls

### DIFF
--- a/bin/draccus.js
+++ b/bin/draccus.js
@@ -48,6 +48,11 @@ sqs.getQueueUrl({'QueueName': options.queueName}, function (err, data) {
       .setQueueUrl(data['QueueUrl'])
       .setStopWhenEmpty(!options.daemon)
       .setVisibilityTimeSec(options.flushFrequency * 1.25) // Extra 25% leeway to ack messages.
+    
+    // do not allow falsy values (espcially not 0)
+    if (options.maxConcurrentReceivers) {
+      sink.setMaxConcurrentReceivers(options.maxConcurrentReceivers)
+    }
 
     if (options.s3Bucket) {
       var s3 = new AWS.S3(options)

--- a/lib/SqsSink.js
+++ b/lib/SqsSink.js
@@ -36,6 +36,9 @@ function SqsSink(sqs, logRawMessage) {
   /** How long to wait for if there are no messages currently in the queue. */
   this._waitTimeSec = 10
 
+  /** The maximum number of fetching calls to run at any given time. */
+  this._maxConcurrentReceivers = 1
+
   /**
    * Specifies how long to SQS should wait for messages to be acked before
    * allowing them to be processed again.  This should be set high enough for
@@ -54,6 +57,9 @@ function SqsSink(sqs, logRawMessage) {
 
   /** Whether the sink is already polling for messages. */
   this._receiving = false
+
+  /** The number of sent sqs.receive() calls that we are still waiting for. */
+  this._waiting_receiver = 0
 }
 util.inherits(SqsSink, EventEmitter)
 module.exports = SqsSink
@@ -116,6 +122,16 @@ SqsSink.prototype.setQueueUrl = function (queueUrl) {
 
 
 /**
+ * Set the maximum number of fetching calls to run at any given time
+ * @param {number} maxConcurrentReceivers
+ * @return {SqsSink}
+ */
+SqsSink.prototype.setMaxConcurrentReceivers = function (maxConcurrentReceivers) {
+  this._maxConcurrentReceivers = maxConcurrentReceivers
+  return this
+}
+
+/**
  * @return {boolean} Whether the sink is polling for messages.
  */
 SqsSink.prototype.isReceiving = function () {
@@ -143,11 +159,17 @@ SqsSink.prototype.startReceiving = function () {
   if (this._receiving) return
   logger.info('Checking SQS for messages: ' + this._queueUrl)
   this._receiving = true
-  this._receiveInternal()
+  for (var i = 0; i < this._maxConcurrentReceivers; i++) {
+    this._receiveInternal()
+  }
 }
 
 
 SqsSink.prototype._receiveInternal = function () {
+  // This is just a safe guard
+  if (this._waiting_receiver >= this._maxConcurrentReceivers) return
+
+  this._waiting_receiver++
   this._sqs.receiveMessage({
     'QueueUrl': this._queueUrl,
     'MaxNumberOfMessages': this._maxMessages,
@@ -188,6 +210,7 @@ SqsSink.prototype._onAcknowledge = function (err, data) {
 
 
 SqsSink.prototype._onReceive = function (err, data) {
+  this._waiting_receiver--
   if (err) {
     logger.error('Failed receiving messages', err.statusCode, err.stack)
     // TODO(dan): Add max retries for non-daemon mode.
@@ -237,7 +260,6 @@ SqsSink.prototype._onQueryAttributes = function (err, data) {
     // If the query failed, try the queue again for more messages.
     this._receiveDelayed()
   } else {
-
     var messageCount = Number(data['Attributes']['ApproximateNumberOfMessages'] || 0)
     var notVisibleCount = Number(data['Attributes']['ApproximateNumberOfMessagesNotVisible'] || 0)
     var delayedCount = Number(data['Attributes']['ApproximateNumberOfMessagesDelayed'] || 0)

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,6 +30,8 @@ flags.defineBoolean('daemon', false, 'Whether the process should stay running on
     'is empty, and wait for further messages.')
 flags.defineString('log_file', '', 'A file to write logs to.')
 
+flags.defineNumber('max_concurrent_receivers', 0, 'The maximum number of fetching calls to run at any given time')
+
 flags.parse()
 
 module.exports = createOptions()
@@ -85,6 +87,8 @@ function createOptions() {
 
   // Force API version.
   options.apiVersion = '2012-11-05'
+
+  options.maxConcurrentReceivers = flags.get('max_concurrent_receivers')
 
   return options
 }


### PR DESCRIPTION
Hello @dpup, @dudeche, @giannic, 

Please review the following commits I made in branch 'xiao-usain-bolt'.

646f9372ba05a4dba7d3e06fecdce68c1bf7cd39 (2014-09-06 00:05:23 -0700)
```
Allow multiple pending sqs.receiveMessage() calls

The current code waits until one sqs.receiveMessage() finishes before
making another sqs.receiveMessage() call. This is inefficient, given
that Draccus is almost completely I/O bound.

This changes allows multiple sqs.receiveMessage() calls to be made
concurrently. However, each of them will act individually. The maximum
number of calls can be capped by a new cli option - max_concurrent_receivers.

Upon errors or empty messages, Draccus will still back off with longer
and longer timeout. When things go back normal, multiple receiving calls
will start active again. This respects the original behavior.

One pitfall of this change is that we are missing control on back
pressure. More specifically, if the store classes cannot write data
out fast enough, and there are a lot of messages in the queue, SqsSink
will quickly fill up memory. So be cautious about the concurrent
value.

An alternative approach is to use Node.js' stream API, which manage
back pressure under the scene.

Ideally, the sinking performance is proportional to the number of
concurrent receivers, until the network is saturated or SQS's output
throughput is saturated. A limited experiement agrees with it.

1 receiver to sink 300 messages - 14.012 sec
2 receivers to sink 300 messages - 6.301 sec
4 receivers to sink 300 messages - 3.94 sec
```

R=@dpup
R=@dudeche
R=@giannic