### PR TITLE
add cli argument for sslEnabled

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -16,6 +16,7 @@ flags.defineString('secret_access_key', '', 'Your AWS secret access key.')
 flags.defineString('metadata_service_host', '', 'IAM metadata service (default: 169.254.169.254).')
 flags.defineString('region', '', 'The AWS Region where the queue resides, overrides config file.')
 flags.defineString('queue_name', '', 'The name of the SQS queue to receive messages from.')
+flags.defineBoolean('sslEnabled', true, 'Whether SSL should be used when communicating with AWS')
 
 flags.defineString('s3_bucket', '', 'The S3 bucket where messages should be written')
 flags.defineString('out_dir', '', 'Local directory where files will be written')
@@ -61,6 +62,7 @@ function createOptions() {
   if (flags.get('access_key_id')) options.accessKeyId = flags.get('access_key_id')
   if (flags.get('secret_access_key')) options.secretAccessKey = flags.get('secret_access_key')
   if (flags.get('metadata_service_host')) options.metadataServiceHost = flags.get('metadata_service_host')
+  if (flags.get('sslEnabled')) options.sslEnabled = flags.get('sslEnabled')
 
   // Non AWS config options, but included for convenience, will be removed
   // before being passed to the AWS SDK.


### PR DESCRIPTION
Hello @dpup, @huckphin,

Please review the following commits I made in branch 'ddb-add-ssl-enabled-cli-option'.

My wrapper bash script for draining queues is configfile-less. Doesn't look like
we grab this option from the CLI.  I'm not even sure this is necessary, but wanted
to throw this out there.

3a9fe3317b51da14d429b745fd198687c4e423c4 (2014-11-03 12:14:07 -0800)
add cli argument for sslEnabled

R=@dpup
R=@huckphin
