### PR TITLE
Move nodeunit into devDependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,3 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "0.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
+# Enables support for a docker container-based build
+# which should provide faster startup times and beefier
+# "machines".
+# See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
+sudo: false
+
 language: node_js
 node_js:
+  - "0.12"
   - "0.10"
   - "0.8"

--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "aws-sdk": "1.18.0",
     "flags": "0.1.1",
     "logg": "0.3.0",
-    "moment": "2.5.1",
-    "nodeunit": "0.8.6"
+    "moment": "2.5.1"
   },
-  "main": "lib/draccus.js"
+  "main": "lib/draccus.js",
+  "devDependencies": {
+    "nodeunit": "0.8.6"
+  }
 }


### PR DESCRIPTION
Hello @dpup, @dudeche, 

Please review the following commits I made in branch 'jsirois/draccus/fix_deps'.

f5213a16510310823ad3c1134b194fbc5c0476f6 (2015-08-25 13:27:31 -0600)
Move nodeunit into devDependencies.
This also gets Travis testing against node 0.12 and using the new
container infrastructure.

R=@dpup
R=@dudeche

MANUAL TESTING=rm -rf node_modules/ && npm install && npm test

Found this exploring draccus as my sample project for pants node
support as suggested by @huckphin.  I selected you as reviewers
via git log stats.